### PR TITLE
Add `AMALGAMATE` option for linking addons

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@
 
 #### `include_bare_module(<specifier> <result>)`
 
-#### `link_bare_module(<receiver> <specifier> [AMALGAMATED [EXCLUDE <...targets>]])`
+#### `link_bare_module(<receiver> <specifier> [AMALGAMATE [EXCLUDE <...targets>]])`
 
-#### `link_bare_modules(<receiver>)`
+#### `link_bare_modules(<receiver> [AMALGAMATE [EXCLUDE <...targets>]])`
 
 #### `bare_include_directories(<result>)`
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 #### `include_bare_module(<specifier> <result>)`
 
-#### `link_bare_module(<receiver> <specifier>)`
+#### `link_bare_module(<receiver> <specifier> [AMALGAMATED [EXCLUDE <...targets>]])`
 
 #### `link_bare_modules(<receiver>)`
 

--- a/bare.cmake
+++ b/bare.cmake
@@ -300,7 +300,7 @@ endfunction()
 
 function(link_bare_module receiver specifier)
   cmake_parse_arguments(
-    PARSE_ARGV 2 ARGV "AMALGAMATED" "" "DEPENDS"
+    PARSE_ARGV 2 ARGV "AMALGAMATED" "" "EXCLUDE"
   )
 
   include_bare_module(${specifier} target)
@@ -327,7 +327,7 @@ function(link_bare_module receiver specifier)
     while(length GREATER 0)
       list(POP_FRONT queue dependency)
 
-      if(NOT ${dependency} IN_LIST seen)
+      if(NOT ${dependency} IN_LIST seen AND NOT ${dependency} IN_LIST ARGV_EXCLUDE)
         list(APPEND seen ${dependency})
 
         if(NOT $<TARGET_OBJECTS:${dependency}> IN_LIST sources)

--- a/bare.cmake
+++ b/bare.cmake
@@ -300,7 +300,7 @@ endfunction()
 
 function(link_bare_module receiver specifier)
   cmake_parse_arguments(
-    PARSE_ARGV 2 ARGV "AMALGAMATED" "" "EXCLUDE"
+    PARSE_ARGV 2 ARGV "AMALGAMATE" "" "EXCLUDE"
   )
 
   include_bare_module(${specifier} target)
@@ -317,41 +317,57 @@ function(link_bare_module receiver specifier)
       ${target}
   )
 
-  if(ARGV_AMALGAMATED)
+  if(ARGV_AMALGAMATE)
     get_target_property(queue ${target} LINK_LIBRARIES)
 
-    list(LENGTH queue length)
-
-    get_target_property(sources ${receiver} SOURCES)
-
-    while(length GREATER 0)
-      list(POP_FRONT queue dependency)
-
-      if(NOT ${dependency} IN_LIST seen AND NOT ${dependency} IN_LIST ARGV_EXCLUDE)
-        list(APPEND seen ${dependency})
-
-        if(NOT $<TARGET_OBJECTS:${dependency}> IN_LIST sources)
-          target_sources(
-            ${receiver}
-            PUBLIC
-              $<TARGET_OBJECTS:${dependency}>
-          )
-        endif()
-
-        get_target_property(dependencies ${dependency} LINK_LIBRARIES)
-
-        if(NOT "${dependencies}" MATCHES "NOTFOUND")
-          list(APPEND queue ${dependencies})
-        endif()
-      endif()
-
+    if(NOT "${queue}" MATCHES "NOTFOUND")
       list(LENGTH queue length)
-    endwhile()
+
+      get_target_property(sources ${receiver} SOURCES)
+
+      list(APPEND seen ${ARGV_EXCLUDE})
+
+      while(length GREATER 0)
+        list(POP_FRONT queue dependency)
+
+        if(NOT ${dependency} IN_LIST seen)
+          list(APPEND seen ${dependency})
+
+          if(NOT $<TARGET_OBJECTS:${dependency}> IN_LIST sources)
+            target_sources(
+              ${receiver}
+              PUBLIC
+                $<TARGET_OBJECTS:${dependency}>
+            )
+          endif()
+
+          get_target_property(dependencies ${dependency} LINK_LIBRARIES)
+
+          if(NOT "${dependencies}" MATCHES "NOTFOUND")
+            list(APPEND queue ${dependencies})
+          endif()
+        endif()
+
+        list(LENGTH queue length)
+      endwhile()
+    endif()
   endif()
 endfunction()
 
 function(link_bare_modules receiver)
+  cmake_parse_arguments(
+    PARSE_ARGV 1 ARGV "AMALGAMATE" "" "EXCLUDE"
+  )
+
   file(GLOB packages node_modules/*/package.json)
+
+  if(ARGV_AMALGAMATE)
+    list(APPEND args AMALGAMATE)
+
+    if(ARGV_EXCLUDE)
+      list(APPEND args EXCLUDE ${ARGV_EXCLUDE})
+    endif()
+  endif()
 
   foreach(package_path ${packages})
     file(READ "${package_path}" package)
@@ -361,7 +377,7 @@ function(link_bare_modules receiver)
     if(error MATCHES "NOTFOUND")
       string(JSON name GET "${package}" "name")
 
-      link_bare_module(${receiver} ${name})
+      link_bare_module(${receiver} ${name} ${args})
     endif()
   endforeach()
 endfunction()


### PR DESCRIPTION
When `AMALGAMATE` is passed, `link_bare_module()` will amalgamate the target objects of the entire link dependency tree and include them as sources of the receiver target. This makes it simple to include all dependant objects into a single, static library.

It does come with an important caveat: If the link dependency tree includes objects that are already included elsewhere, callers run the risk of symbol duplication.

As an example, consider the following static library declaration:

```cmake
add_library(my_lib STATIC)

target_link_libraries(
  my_lib
  PUBLIC
    $<LINK_LIBRARY:WHOLE_ARCHIVE,bare_static>
)
```

If we want to bundle an addon, such as `sodium-native`, into the resulting `.a`/`.lib` archive, we can do the following:

```cmake
link_bare_module(my_lib sodium-native AMALGAMATE)
```

As `sodium-native` links the static `sodium` library, CMake would normally only create a dependency between our `.a`/`.lib` archive and `libsodium.a`. As a result, we'd _also_ have to include a copy of `libsodium.a` if we wanted to link our final binary outside of CMake.

When passing the `AMALGAMATE ` option, however, we add the objects of the `sodium` library _directly_ to our own library and they're therefore included in the resulting `.a`/`.lib` archive. As such, we do run the risk of symbol duplication, which can be solved with the accompanying `EXCLUDE` option. For example, `bare-url` links the static `utf` library, which is already linked to Bare itself. The following declaration will therefore cause a link error due to the `utf` symbols being duplicated:

```cmake
link_bare_module(my_lib bare-url AMALGAMATE)
```

To fix it, we can manually exclude the `utf` objects:

```cmake
link_bare_module(${name} bare-url AMALGAMATE EXCLUDE utf)
```